### PR TITLE
Specify run_as_user for windows_service

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,8 @@
 # This recipe will Configure w32time service to use ntp
 
 # Make sure w32time service is running
-service 'w32time' do
+windows_service 'w32time' do
+  run_as_user 'NT AUTHORITY\LocalService'
   action %i[enable start]
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,5 +25,5 @@ registry_key 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Param
           { name: 'Type', type: :string, data: node['w32time']['type'] }]
   action :create
   notifies :run, 'execute[set ntp config]', :immediately
-  notifies :restart, 'service[w32time]', :immediately
+  notifies :restart, 'windows_service[w32time]', :immediately
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -12,7 +12,7 @@ describe 'w32time::default' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'windows',
-        version:  '2012R2',
+        version:  '2016',
       )
       runner.converge(described_recipe)
     end


### PR DESCRIPTION
* Last versions of Chef is using a default value for run_as_user
* The default value is "LocalSystem" and here the service is created
  with the "LocalService" user

Change-Id: Ib6979ca60af5a77d01ca78ef5e7b7bcbf06a0cd8